### PR TITLE
[#118695049] Fix mixed-content error of loading http over https scheme after disconnection from social account

### DIFF
--- a/social/actions.py
+++ b/social/actions.py
@@ -110,8 +110,10 @@ def do_disconnect(backend, user, association_id=None, redirect_name='next',
 
     if isinstance(response, dict):
         response = backend.strategy.redirect(
-            backend.strategy.request_data().get(redirect_name, '') or
-            backend.setting('DISCONNECT_REDIRECT_URL') or
-            backend.setting('LOGIN_REDIRECT_URL')
+            backend.strategy.absolute_uri(
+                backend.strategy.request_data().get(redirect_name, '') or
+                backend.setting('DISCONNECT_REDIRECT_URL') or
+                backend.setting('LOGIN_REDIRECT_URL')
+            )
         )
     return response


### PR DESCRIPTION
The three possible sources of **redirect-uri** to `backend.strategy.redirect()` call would most likely supply a relative uri. From my encounter with this, the **redirect-uri** got loaded over http which caused Mixed-content error since the social platform disconnection request was made over https scheme.

So passing any of the relative **redirect-uri** to `backend.strategy.absolute_uri()` would pass the absolute **redirect-uri** with the desired scheme to `backend.strategy.redirect()`.
